### PR TITLE
Add ability to configure the apache logs and collect them

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,28 @@ Tune security settings (these are default):
           # Set X-Frame-Options
           frame_options: sameorigin
 
+Tune the log configuration:
+
+.. code-block:: yaml
+
+    parameters:
+      apache:
+        server:
+          site:
+            foo:
+              enabled: true
+              type: static
+              log:
+                custom:
+                  enabled: true
+                  file: /var/log/apache2/mylittleponysitecustom.log
+                  format: >-
+                     %{X-Forwarded-For}i %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\"
+                error:
+                  enabled: false
+                  file: /var/log/apache2/foo.error.log
+                  level: notice
+
 Example pillar
 ==============
 

--- a/apache/files/_log.conf
+++ b/apache/files/_log.conf
@@ -1,5 +1,11 @@
+{%- from "apache/map.jinja" import server with context %}
+{%- set error_log = site.get('log', {}).get('error', {}) %}
+{%- set custom_log = site.get('log', {}).get('custom', {}) %}
 
-	LogLevel warn
-
-	ErrorLog /var/log/apache2/{{ site_name }}.error.log
-	CustomLog /var/log/apache2/{{ site_name }}.access.log vhost_combined
+{%- if error_log.get('enabled', True) %}
+    LogLevel {{ error_log.level|default('warn') }}
+    ErrorLog {{ error_log.file|default(server.log_dir ~ '/' ~ site_name ~ '.error.log') }}
+{%- endif %}
+{%- if custom_log.get('enabled', True) %}
+    CustomLog {{ custom_log.file|default(server.log_dir ~ '/' ~ site_name ~ '.access.log') }} "{{ custom_log.format|default('vhost_combined') }}"
+{%- endif %}

--- a/apache/meta/heka.yml
+++ b/apache/meta/heka.yml
@@ -1,0 +1,33 @@
+{%- from "apache/map.jinja" import server with context %}
+{%- if server.get('enabled', False) and server.site is defined %}
+
+log_collector:
+  decoder:
+{%- for site_name, site in server.site.iteritems() %}
+{%- if site.type == 'keystone' %}
+    keystone_wsgi:
+      engine: sandbox
+      module_file: /usr/share/lma_collector/decoders/keystone_wsgi_log.lua
+      module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
+      config:
+        apache_log_pattern: >-
+          {{ site.get('log', {}).get('custom', {}).format|default('vhost_combined') }}
+{%- endif %}
+{%- endfor %}
+
+  input:
+{%- for site_name, site in server.site.iteritems() %}
+{%- if site.type == 'keystone' %}
+{%- set apache_log_file = site.get('log', {}).get('custom', {}).file|default(server.log_dir ~ '/' ~ site_name ~ '.access.log') %}
+    keystone_wsgi_log:
+      engine: logstreamer
+      log_directory: "{{ salt['file.dirname'](apache_log_file) }}"
+      file_match: '{{ salt['file.basename'](apache_log_file)|replace('.', '\.') }}\.?(?P<Seq>\d*)$'
+      differentiator: ['keystone-wsgi']
+      priority: ["^Seq"]
+      decoder: "keystone_wsgi_decoder"
+      splitter: "TokenSplitter"
+{%- endif %}
+{%- endfor %}
+
+{%- endif %}


### PR DESCRIPTION
This change adds a new parameter to change the access log format. If
absent, the default is 'vhost_combined' as before.